### PR TITLE
Add support for ARM64 architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,21 @@ ENV LC_ALL ${DEFAULT_LOCALE}
 # Install Silverpeas and Wildfly
 #
 
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/sh'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
+
 # Set up environment variables for Silverpeas
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /docker-java-home
 ENV SILVERPEAS_HOME /opt/silverpeas
 ENV JBOSS_HOME /opt/wildfly
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -60,8 +60,21 @@ ENV LC_ALL ${DEFAULT_LOCALE}
 # Install Silverpeas and Wildfly
 #
 
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+		echo '#!/bin/sh'; \
+		echo 'set -e'; \
+		echo; \
+		echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+	} > /usr/local/bin/docker-java-home \
+	&& chmod +x /usr/local/bin/docker-java-home
+
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
+
 # Set up environment variables for Silverpeas
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /docker-java-home
 ENV SILVERPEAS_HOME /opt/silverpeas
 ENV JBOSS_HOME /opt/wildfly
 


### PR DESCRIPTION
```Silverpeas``` is building and running fine on ```arm64v8``` architecture as well.
The only issue was due to the hard-coded ```JAVA_HOME``` environment variable.

Once this is fixed, ```silverpeas``` is good to run on multiple platforms.

Regards,