### PR TITLE
Chore: reduce attack surface and size for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ENV TERM=xterm
 # Installation of LibreOffice, ImageMagick, Ghostscript, and then
 # the dependencies required to run SWFTools and PDF2JSON
 RUN apt-get update \
-  && apt-get install -y tzdata \ 
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends tzdata \ 
+  && apt-get install -y --no-install-recommends \
     apt-utils \
     iputils-ping \
     curl \


### PR DESCRIPTION
Hi,

This pull request includes a small improvement for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

In detail:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. Not only can this change trim your image size but it also can also reduce the attack surface.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.